### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "author": "JP",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "npm": "^6.9.0"
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",


### PR DESCRIPTION

Hello joshuapeters!

It seems like you have npm as one of your (dev-) dependency in ssbu-fight-util.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
